### PR TITLE
Add `GetFormulation` impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,21 +197,29 @@ formulation.
 neuronek formulation create --name <FORMULATION_NAME>  
 ```
 
+```present cargo run -- --format pretty formulation create --name "Quilla Mind"
+╭────┬─────────────┬─────────────┬─────────────╮
+│ id │ name        │ description │ ingredients │
+├────┼─────────────┼─────────────┼─────────────┤
+│ 2  │ quilla mind │ ---         │ {}          │
+╰────┴─────────────┴─────────────┴─────────────╯
+```
+
 #### Get Formulation
 
 Retrieves details about a specific formulation, including its name, description, and list of ingredients with their
 respective quantities.
 
 ```bash
-neuronek formulation <FORMULATION_ID> # OR neuronek formulation get <FORMULATION_ID>
+neuronek formulation get <FORMULATION_ID>
 ```
 
-```present cargo run -- --format pretty formulation 1
-╭────┬──────┬─────────────┬─────────────╮
-│ id │ name │ description │ ingredients │
-├────┼──────┼─────────────┼─────────────┤
-│ 1  │ xd   │ ---         │ {}          │
-╰────┴──────┴─────────────┴─────────────╯
+```present cargo run -- --format pretty formulation get 1
+╭────┬─────────────┬─────────────┬─────────────╮
+│ id │ name        │ description │ ingredients │
+├────┼─────────────┼─────────────┼─────────────┤
+│ 1  │ quilla mind │ ---         │ {}          │
+╰────┴─────────────┴─────────────┴─────────────╯
 ```
 
 #### List Formulations

--- a/src/cli/formulation.rs
+++ b/src/cli/formulation.rs
@@ -5,10 +5,10 @@ use futures::prelude::*;
 use sea_orm::TransactionTrait;
 use serde::Serialize;
 
+use crate::Application;
 use crate::cli::Displayable;
 use crate::formulation::ingredient::Ingredient;
-use crate::formulation::{create_formulation, Command as FormulationCommand, Formulation};
-use crate::Application;
+use crate::formulation::{Command as FormulationCommand, Formulation, create_formulation, get_formulation};
 
 impl Displayable for Formulation
 {
@@ -49,7 +49,10 @@ pub fn handle(command: Command, application: &Application)
 			| FormulationCommand::Update(_) => {}
 			| FormulationCommand::Delete(_) => {}
 			| FormulationCommand::List(_) => {}
-			| FormulationCommand::Get(_) => {}
+			| FormulationCommand::Get(cmd) => {
+				let formulation = get_formulation(&cmd, &transaction).await.unwrap();
+				formulation.display(application.stdout_format.clone());
+			}
 		};
 
 		transaction.commit().await.unwrap()

--- a/src/formulation/mod.rs
+++ b/src/formulation/mod.rs
@@ -181,24 +181,64 @@ async fn list_formulations(
 async fn should_list_formulations() {}
 
 #[derive(Debug, Clone, Args)]
-
-pub struct GetFormulation
-{
-	#[arg(index = 1, value_name = "FORMULATION_ID")]
-	id: i32,
+pub struct GetFormulation {
+    #[arg(index = 1, value_name = "FORMULATION_ID")]
+    id: i32,
 }
 
+pub async fn get_formulation(
+    get_formulation: &crate::formulation::GetFormulation,
+    transaction: &DatabaseTransaction,
+) -> miette::Result<Formulation> {
+    use sea_orm::{EntityTrait, ColumnTrait, QueryFilter};
 
-async fn get_formulation(
-	get_formulation: &crate::formulation::GetFormulation, transaction: &DatabaseTransaction,
-) -> miette::Result<Formulation>
-{
-	todo!()
+    let formulation = Entity::find()
+        .filter(crate::database::entities::formulation::Column::Id.eq(get_formulation.id))
+        .one(transaction)
+        .await.into_diagnostic()?
+        .ok_or_else(|| miette::miette!("Formulation not found"))?;
+
+	Ok(Formulation {
+		id: Some(formulation.id),
+	    name: FormulationName::try_from(formulation.name).into_diagnostic()?,
+		description: formulation.summary,
+		ingredients: HashSet::new(),
+	})
 }
-
 
 #[async_std::test]
-async fn should_get_formulation() {}
+async fn should_get_formulation() {
+    use sea_orm::EntityTrait;
+
+    use super::*;
+    let db_connection = &DATABASE_CONNECTION;
+    let tx = db_connection.begin().await.unwrap();
+	
+    let created_formulation = create_formulation(
+        &CreateFormulation {
+            name: "test formulation".into(),
+            description: Some("Test description".into()),
+        },
+        &tx,
+    )
+    .await
+    .unwrap();
+	
+    let result = get_formulation(
+        &GetFormulation {
+            id: created_formulation.id.unwrap(),
+        },
+        &tx,
+    )
+    .await
+    .unwrap();
+
+    tx.commit().await.unwrap();
+	
+    assert_eq!(result.id, created_formulation.id);
+    assert_eq!(result.name.to_string(), "test formulation");
+    assert_eq!(result.description, Some("Test description".into()));
+}
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum Command


### PR DESCRIPTION
Add `GetFormulation` function to fetch formulation details using an ID. It also integrates this feature into the CLI for displaying information in the desired output format. Additionally, the README has been updated with usage examples, and related tests have been refined to ensure functionality. 

### Changes

- Added `GetFormulation` function for formulation retrieval by ID.
- Integrated functionality into the CLI.
- Updated README with relevant usage examples.
- Improved and expanded related tests for coverage.